### PR TITLE
Made the program exitable by ExitCommand

### DIFF
--- a/src/Unit-1/lesson5/Completed/FileValidatorActor.cs
+++ b/src/Unit-1/lesson5/Completed/FileValidatorActor.cs
@@ -22,9 +22,6 @@ namespace WinTail
             {
                 // signal that the user needs to supply an input
                 _consoleWriterActor.Tell(new Messages.NullInputError("Input was blank. Please try again.\n"));
-
-                // tell sender to continue doing its thing (whatever that may be, this actor doesn't care)
-                Sender.Tell(new Messages.ContinueProcessing());
             }
             else
             {
@@ -42,13 +39,10 @@ namespace WinTail
                     // signal that input was bad
                     _consoleWriterActor.Tell(new Messages.ValidationError(string.Format("{0} is not an existing URI on disk.", msg)));
 
-                    // tell sender to continue doing its thing (whatever that may be, this actor doesn't care)
-                    Sender.Tell(new Messages.ContinueProcessing());
                 }
             }
-
-
-
+            // tell sender to continue doing its thing (whatever that may be, this actor doesn't care)
+            Sender.Tell(new Messages.ContinueProcessing());
         }
 
         /// <summary>


### PR DESCRIPTION
The ConsoleReaderActor in Unit1 Lesson 5 onwards doesn't get told to "ContinueProcessing" in a successfull case right now. This change would enable the user to exit the program by typing exit again.