### PR TITLE
Fixed typo on lesson 2.3

### DIFF
--- a/src/Unit-2/lesson3/README.md
+++ b/src/Unit-2/lesson3/README.md
@@ -120,7 +120,7 @@ These are the various API calls you can make to schedule recurring messages.
 public Task Schedule(TimeSpan initialDelay, TimeSpan interval, Action action);
 public Task Schedule(TimeSpan initialDelay, TimeSpan interval, Action action, CancellationToken cancellationToken);
 public Task Schedule(TimeSpan initialDelay, TimeSpan interval, ActorRef receiver, object message);
-public Task Schedule(TimeSpan initialDelay, TimeSpan interval, ActorRef receiver, object message, CancellationToken
+public Task Schedule(TimeSpan initialDelay, TimeSpan interval, ActorRef receiver, object message, CancellationToken cancellationToken);
 ```
 
 #### Overloads of `ScheduleOnce`


### PR DESCRIPTION
Typo on one of the overloads of Schedule()