### PR TITLE
Including akka.net namespace in Unit 1

### DIFF
--- a/src/Unit-1/DoThis/Program.cs
+++ b/src/Unit-1/DoThis/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+﻿using Akka.Actor;
 
 namespace WinTail
 {


### PR DESCRIPTION
This ensures that the solution will compile after you open it. It's always a bummer if you open a solution and it doesn't compile right away. Even though this is explicitly mentioned in the documentation.