### PR TITLE
Fixed bug in Unit-1\lesson 4

### DIFF
--- a/src/Unit-1/lesson4/README.md
+++ b/src/Unit-1/lesson4/README.md
@@ -115,7 +115,7 @@ Every actor has an address. To send a message from one actor to another, you jus
 
 > *The "Path" portion of an actor address is just a description of where that actor is in your actor hierarchy. Each level of the hierarchy is separated by a single slash ('/').*
 
-For example, if we were running on `localhost`, the full address of actor `b2` would be `akka.tcp://MyActorSystem@localhost:9001/user/a1/b2`.
+For example, if we were running on `localhost`, the full address of actor `b2` would be `akka.tcp://MyActorSystem@localhost:9001/user/a2/b2`.
 
 One question that comes up a lot is, "Do my actor classes have to live at a certain point in the hierarchy?" For example, if I have an actor class, `FooActor`—can I only deploy that actor as a child of `BarActor` on the hierarchy? Or can I deploy it anywhere?
 


### PR DESCRIPTION
Fixed bug in chapter 'Actor path == actor position in hierarchy', where
the path to 'b2' was incorrect.