### PR TITLE
Simplify aggregation of points in ChartingActor.SetChartBoundaries()

### DIFF
--- a/src/Unit-2/lesson3/Completed/Actors/ChartingActor.cs
+++ b/src/Unit-2/lesson3/Completed/Actors/ChartingActor.cs
@@ -148,8 +148,8 @@ namespace ChartApp.Actors
         private void SetChartBoundaries()
         {
             double maxAxisX, maxAxisY, minAxisX, minAxisY = 0.0d;
-            var allPoints = _seriesIndex.Values.Aggregate(new HashSet<DataPoint>(), (set, series) => new HashSet<DataPoint>(set.Concat(series.Points)));
-            var yValues = allPoints.Aggregate(new List<double>(), (list, point) => list.Concat(point.YValues).ToList());
+            var allPoints = _seriesIndex.Values.SelectMany(series => series.Points).ToList();
+            var yValues = allPoints.SelectMany(point => point.YValues).ToList();
             maxAxisX = xPosCounter;
             minAxisX = xPosCounter - MaxPoints;
             maxAxisY = yValues.Count > 0 ? Math.Ceiling(yValues.Max()) : 1.0d;

--- a/src/Unit-2/lesson3/README.md
+++ b/src/Unit-2/lesson3/README.md
@@ -787,9 +787,8 @@ Add the following method to the bottom of the `ChartingActor` class (don't worry
 private void SetChartBoundaries()
 {
     double maxAxisX, maxAxisY, minAxisX, minAxisY = 0.0d;
-    var allPoints = _seriesIndex.Values.Aggregate(new HashSet<DataPoint>(),
-			(set, series) => new HashSet<DataPoint>(set.Concat(series.Points)));
-    var yValues = allPoints.Aggregate(new List<double>(), (list, point) => list.Concat(point.YValues).ToList());
+    var allPoints = _seriesIndex.Values.SelectMany(series => series.Points).ToList();
+    var yValues = allPoints.SelectMany(point => point.YValues).ToList();
     maxAxisX = xPosCounter;
     minAxisX = xPosCounter - MaxPoints;
     maxAxisY = yValues.Count > 0 ? Math.Ceiling(yValues.Max()) : 1.0d;

--- a/src/Unit-2/lesson4/Completed/Actors/ChartingActor.cs
+++ b/src/Unit-2/lesson4/Completed/Actors/ChartingActor.cs
@@ -186,8 +186,8 @@ namespace ChartApp.Actors
         private void SetChartBoundaries()
         {
             double maxAxisX, maxAxisY, minAxisX, minAxisY = 0.0d;
-            var allPoints = _seriesIndex.Values.Aggregate(new HashSet<DataPoint>(), (set, series) => new HashSet<DataPoint>(set.Concat(series.Points)));
-            var yValues = allPoints.Aggregate(new List<double>(), (list, point) => list.Concat(point.YValues).ToList());
+            var allPoints = _seriesIndex.Values.SelectMany(series => series.Points).ToList();
+            var yValues = allPoints.SelectMany(point => point.YValues).ToList();
             maxAxisX = xPosCounter;
             minAxisX = xPosCounter - MaxPoints;
             maxAxisY = yValues.Count > 0 ? Math.Ceiling(yValues.Max()) : 1.0d;

--- a/src/Unit-2/lesson5/Completed/Actors/ChartingActor.cs
+++ b/src/Unit-2/lesson5/Completed/Actors/ChartingActor.cs
@@ -192,8 +192,8 @@ namespace ChartApp.Actors
         private void SetChartBoundaries()
         {
             double maxAxisX, maxAxisY, minAxisX, minAxisY = 0.0d;
-            var allPoints = _seriesIndex.Values.Aggregate(new HashSet<DataPoint>(), (set, series) => new HashSet<DataPoint>(set.Concat(series.Points)));
-            var yValues = allPoints.Aggregate(new List<double>(), (list, point) => list.Concat(point.YValues).ToList());
+            var allPoints = _seriesIndex.Values.SelectMany(series => series.Points).ToList();
+            var yValues = allPoints.SelectMany(point => point.YValues).ToList();
             maxAxisX = xPosCounter;
             minAxisX = xPosCounter - MaxPoints;
             maxAxisY = yValues.Count > 0 ? Math.Ceiling(yValues.Max()) : 1.0d;


### PR DESCRIPTION
The use of the LINQ `Aggregate` operator in `SetChartBoundaries()` made the code difficult for me to understand on initially reading it. 

I think the use of LINQ `SelectMany()` in these two lines is cleaner, shorter, and easier to understand.

Also, this revision allows the `allPoints` assignment to use LINQ's `ToList()` method, so that a `HashSet` is not needed; this makes the two lines which collect values read more similarly to each other.