### PR TITLE
Fixed spelling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Akka.NET Bootcamp
 
-WWelcome to [Akka.NET](http://getakka.net/ "Akka.NET - Distributed actor model in C# and F#") Bootcamp! This is a free, self-directed learning course brought to you by the folks at [Petabridge](http://petabridge.com/ "Petabridge - Akka.NET Training, Consulting, and Support").
+Welcome to [Akka.NET](http://getakka.net/ "Akka.NET - Distributed actor model in C# and F#") Bootcamp! This is a free, self-directed learning course brought to you by the folks at [Petabridge](http://petabridge.com/ "Petabridge - Akka.NET Training, Consulting, and Support").
 
 [![Get Akka.NET training material & updates at https://petabridge.com/bootcamp/signup](images/grok.png)](https://petabridge.com/bootcamp/signup)
 

--- a/src/Unit-1/lesson5/README.md
+++ b/src/Unit-1/lesson5/README.md
@@ -48,7 +48,7 @@ Petabridge published a detailed post on this subject aptly titled "[When Should 
 Short version: avoid using `ActorSelection` if you can, but sometimes it's the only way to get into communication with another actor for which you don't currently have an `IActorRef`.
 
 ### Caution: Don't pass `ActorSelection`s around
-We encourage you NOT to pass around `ActorSelection`s as pararmeters, the way you do `IActorRef`s. The reason for this is that `ActorSelection`s can be relative instead of absolute, in which case it wouldn't produce the intended effects when passed to an actor with a different location in the hierarchy.
+We encourage you NOT to pass around `ActorSelection`s as parameters, the way you do `IActorRef`s. The reason for this is that `ActorSelection`s can be relative instead of absolute, in which case it wouldn't produce the intended effects when passed to an actor with a different location in the hierarchy.
 
 ### How do I make an `ActorSelection`?
 Very simple: `var selection = Context.ActorSelection("/path/to/actorName");`

--- a/src/Unit-2/lesson3/README.md
+++ b/src/Unit-2/lesson3/README.md
@@ -185,7 +185,7 @@ Pub/sub is trivial to implement in Akka.NET and it's a pattern you can feel comf
 Now that you're familiar with how the `Scheduler` works, lets put it to use and make our charting UI reactive!
 
 ## Exercise
-**HEADS UP:** This section is where 90% of the work happens in all of Unit 2. We're going to add a few new actors who are responsible for setting up pub/sub relationships with the `ChartingActor` in order to graph `PeformanceCounter` data at regular intervals.
+**HEADS UP:** This section is where 90% of the work happens in all of Unit 2. We're going to add a few new actors who are responsible for setting up pub/sub relationships with the `ChartingActor` in order to graph `PerformanceCounter` data at regular intervals.
 
 ### Step 1 - Delete the "Add Series" Button and Click Handler from Lesson 2
 
@@ -444,22 +444,22 @@ Well, we've got an actor that takes an `IDisposable` object as a parameter. So w
 
 What happens when the `PerformanceCounterActor` needs to restart?
 
-**Every time the `PeformanceCounterActor` attempts to restart it will re-use its original constructor arguments, which includes reference types**. If we re-use the same reference to the now-`Disposed` `PerformanceCounter`, the actor will crash repeatedly. Until its parent decides to just kill it altogether.
+**Every time the `PerformanceCounterActor` attempts to restart it will re-use its original constructor arguments, which includes reference types**. If we re-use the same reference to the now-`Disposed` `PerformanceCounter`, the actor will crash repeatedly. Until its parent decides to just kill it altogether.
 
-A better technique is to pass a factory function that `PerformanceCounterActor` can use to get a fresh instance of its `PeformanceCounter`. That's why we use a `Func<PerformanceCounter>` in the constructor, which gets invoked during the actor's `PreStart()` lifecycle method.
+A better technique is to pass a factory function that `PerformanceCounterActor` can use to get a fresh instance of its `PerformanceCounter`. That's why we use a `Func<PerformanceCounter>` in the constructor, which gets invoked during the actor's `PreStart()` lifecycle method.
 
 ```csharp
 // create a new instance of the performance counter from factory that was passed in
 _counter = _performanceCounterGenerator();
 ```
 
-Because our `PeformanceCounter` is `IDisposable`, we also need to clean up the `PeformanceCounter` instance inside the `PostStop` lifecycle method of the actor.
+Because our `PerformanceCounter` is `IDisposable`, we also need to clean up the `PerformanceCounter` instance inside the `PostStop` lifecycle method of the actor.
 
 We already know that we're going to get a fresh instance of that counter when the actor restarts, so we want to prevent resource leaks. This is how we do that:
 
 ```csharp
 // Actors/PerformanceCounterActor.cs
-// prevent resource leaks by disposing of our current PeformanceCounter
+// prevent resource leaks by disposing of our current PerformanceCounter
 protected override void PostStop()
 {
     try
@@ -500,12 +500,12 @@ else if (message is UnsubscribeCounter)
 }
 ```
 
-In this lesson, `PerformanceCounterActor` only has one subscriber (`ChartingActor`, from inside `Main.cs`) but with a little re-architecting you could have these actors publishing their `PeformanceCounter` data to multiple recipients. Maybe that's a do-it-yourself exercise you can try later? ;)
+In this lesson, `PerformanceCounterActor` only has one subscriber (`ChartingActor`, from inside `Main.cs`) but with a little re-architecting you could have these actors publishing their `PerformanceCounter` data to multiple recipients. Maybe that's a do-it-yourself exercise you can try later? ;)
 
-#### How did we schedule publishing of `PeformanceCounter` data?
-Inside the `PreStart` lifecycle method, we used the `Context` object to get access to the `Scheduler`, and then we had `PeformanceCounterActor` send itself a `GatherMetrics` method once every 250 milliseconds.
+#### How did we schedule publishing of `PerformanceCounter` data?
+Inside the `PreStart` lifecycle method, we used the `Context` object to get access to the `Scheduler`, and then we had `PerformanceCounterActor` send itself a `GatherMetrics` method once every 250 milliseconds.
 
-This causes `PeformanceCounterActor` to fetch data every 250ms and publish it to `ChartingActor`, giving us a live graph with a frame rate of 4 FPS.
+This causes `PerformanceCounterActor` to fetch data every 250ms and publish it to `ChartingActor`, giving us a live graph with a frame rate of 4 FPS.
 
 ```csharp
 // Actors/PerformanceCounterActor.cs
@@ -534,10 +534,10 @@ The `PerformanceCounterCoordinatorActor` is the interface between the `ChartingA
 
 It has the following jobs:
 
-* Lazily create all `PeformanceCounterActor` instances that are requested by the end-user;
-* Provide the `PeformanceCounterActor` with a factory method (`Func<PerformanceCounter>`) for creating its counters;
+* Lazily create all `PerformanceCounterActor` instances that are requested by the end-user;
+* Provide the `PerformanceCounterActor` with a factory method (`Func<PerformanceCounter>`) for creating its counters;
 * Manage all counter subscriptions for the `ChartingActor`; and
-* Tell the `ChartingActor` how to render each of the individual counter metrics (which colors and plot types to use for each `Series` that corresponds with a `PeformanceCounter`.)
+* Tell the `ChartingActor` how to render each of the individual counter metrics (which colors and plot types to use for each `Series` that corresponds with a `PerformanceCounter`.)
 
 Sounds complicated, right? Well, you'll be surprised when you see how small the code footprint is!
 
@@ -695,7 +695,7 @@ You didn't think we were going to let you just fire off those buttons you create
 
 In this step, we're going to add a new type of actor that will run on the UI thread just like the `ChartingActor`.
 
-The job of the `ButtonToggleActor` is to turn click events on the `Button` it manages into messages for the `PerformanceCounterCoordinatorActor`. The `ButtonToggleActor` also makes sure that the visual state of the `Button` accurately reflects the state of the subscription managed by the `PeformanceCounterCoordinatorActor` (e.g. ON/OFF).
+The job of the `ButtonToggleActor` is to turn click events on the `Button` it manages into messages for the `PerformanceCounterCoordinatorActor`. The `ButtonToggleActor` also makes sure that the visual state of the `Button` accurately reflects the state of the subscription managed by the `PerformanceCounterCoordinatorActor` (e.g. ON/OFF).
 
 Okay, create a new file in the `/Actors` folder called `ButtonToggleActor.cs` and type the following:
 

--- a/src/Unit-2/lesson4/README.md
+++ b/src/Unit-2/lesson4/README.md
@@ -202,7 +202,7 @@ Yes, but the syntax is a little different inside an `UntypedActor`. To switch be
 
 These are the API calls inside an `UntypedActor`:
 
-* `Context.Become(Receive rec)` - changes behavior without preservering the previous behavior on the stack;
+* `Context.Become(Receive rec)` - changes behavior without preserving the previous behavior on the stack;
 * `Context.BecomeStacked(Receive rec)` - pushes a new behavior on the stack or
 * `Context.UnbecomeStacked()` - pops the current behavior and switches to the previous (if applicable.)
 


### PR DESCRIPTION
Change "pararmeters" to "parameters" and "peformance" to "performance"