### PR TITLE
Unit 3 / DoThis ported to F#

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/src/Unit-3/FSharpDoThis/ActorSystem.fs
+++ b/src/Unit-3/FSharpDoThis/ActorSystem.fs
@@ -1,0 +1,6 @@
+﻿namespace GithubActors
+
+open Akka.FSharp
+
+module ActorSystem =
+    let githubActors = System.create "GithubActors" (Configuration.load())

--- a/src/Unit-3/FSharpDoThis/Actors.fs
+++ b/src/Unit-3/FSharpDoThis/Actors.fs
@@ -1,0 +1,412 @@
+﻿namespace GithubActors
+
+open System
+open System.Windows.Forms
+open System.Drawing
+open Akka.FSharp
+open Akka.Actor
+
+[<AutoOpen>]
+module Actors =
+
+    // make a pipe-friendly version of Akka.NET PipeTo for handling async computations
+    let pipeToWithSender recipient sender asyncComp = pipeTo asyncComp recipient sender
+
+    // Helper functions to check the type of query received
+    let isWorkerMessage (someType: obj) = someType.GetType().IsSubclassOf(typeof<GithubActorMessage>)
+
+    let isQueryStarrers (someType: obj) =
+        if isWorkerMessage someType then
+            match someType :?> GithubActorMessage with
+            | QueryStarrers _ -> true
+            | _ -> false
+        else
+            false
+
+    let isQueryStarrer (someType: obj) =
+        if isWorkerMessage someType then
+            match someType :?> GithubActorMessage with
+            | QueryStarrer _ -> true
+            | _ -> false
+        else
+            false
+
+    // Actors
+    let githubAuthenticationActor (statusLabel: Label) (githubAuthForm: Form) (launcherForm: Form) (mailbox: Actor<_>) =
+
+        let cannotAuthenticate reason =
+            statusLabel.ForeColor <- Color.Red
+            statusLabel.Text <- reason
+
+        let showAuthenticatingStatus () =
+            statusLabel.Visible <- true
+            statusLabel.ForeColor <- Color.Orange
+            statusLabel.Text <- "Authenticating..."
+
+        let rec unauthenticated () =
+            actor {
+                let! message = mailbox.Receive ()
+
+                match message with
+                | Authenticate token ->
+                    showAuthenticatingStatus ()
+                    let client = GithubClientFactory.getUnauthenticatedClient ()
+                    client.Credentials <- Octokit.Credentials token
+                    
+                    let continuation (task: System.Threading.Tasks.Task<Octokit.User>) : AuthenticationMessage =
+                        match task.IsFaulted with
+                        | true -> AuthenticationFailed
+                        | false ->
+                            match task.IsCanceled with
+                            | true -> AuthenticationCancelled
+                            | false ->
+                                GithubClientFactory.setOauthToken token
+                                AuthenticationSuccess
+                        
+                    client.User.Current().ContinueWith continuation
+                    |> Async.AwaitTask
+                    |!> mailbox.Self
+
+                    return! authenticating ()
+                | _ -> return! unauthenticated ()
+            }
+        and authenticating () =
+            actor {
+                let! message = mailbox.Receive ()
+
+                match message with
+                | AuthenticationFailed ->
+                    cannotAuthenticate "Authentication failed."
+                    return! unauthenticated ()
+                | AuthenticationCancelled ->
+                    cannotAuthenticate "Authentication timed out."
+                    return! unauthenticated ()
+                | AuthenticationSuccess ->
+                    githubAuthForm.Hide ()
+                    launcherForm.Show ()
+                | _ -> return! authenticating ()
+            }
+            
+        unauthenticated ()
+
+
+    let mainFormActor (isValidLabel: Label) (createRepoResultsForm) (mailbox: Actor<_>) =
+
+        let updateLabel message isValid =
+            isValidLabel.Text <- message
+            if isValid then isValidLabel.ForeColor <- Color.Green else isValidLabel.ForeColor <- Color.Red
+            mailbox.UnstashAll ()
+
+        let rec ready () =
+            actor {
+                let! message = mailbox.Receive ()
+
+                match message with
+                | ProcessRepo uri ->
+                    select "akka://GithubActors/user/validator" mailbox.Context.System <! ValidateRepo uri
+                    isValidLabel.Visible <- true
+                    isValidLabel.Text <- sprintf "Validating %s..." uri
+                    isValidLabel.ForeColor <- Color.Orange
+                    return! busy ()
+                | LaunchRepoResultsWindow (repoKey, coordinator) ->
+                    let repoResultsForm: Form = createRepoResultsForm repoKey coordinator
+                    repoResultsForm.Show ()
+                    return! ready ()
+                | _ -> return! ready ()
+            }
+        and busy () =
+            actor {
+                let! message = mailbox.Receive ()
+
+                match message with
+                | ValidRepo _ ->
+                    updateLabel "Valid!" true
+                    return! ready ()
+                | InvalidRepo (uri, reason) ->
+                    updateLabel reason false
+                    return! ready ()
+                | UnableToAcceptJob job ->
+                    updateLabel (sprintf "%s/%s is a valid repo, but the system cannot accept additional jobs" job.Owner job.Repo) false
+                    return! ready ()
+                | AbleToAcceptJob job ->
+                    updateLabel (sprintf "%s/%s is a valid repo - starting job!" job.Owner job.Repo) true
+                    return! ready ()
+                | LaunchRepoResultsWindow (_, _) ->
+                    mailbox.Stash ()
+                    return! busy ()
+                | _ -> return! busy ()
+            }
+
+        ready ()
+
+
+    let githubValidatorActor (getGithubClient: unit -> Octokit.GitHubClient) (mailbox: Actor<_>) =
+
+        let splitIntoOwnerAndRepo repoUri =
+            let results = Uri(repoUri, UriKind.Absolute).PathAndQuery.TrimEnd('/').Split('/') |> Array.rev
+            (results.[1], results.[0]) // User, Repo
+            
+        let rec processMessage () = actor {
+            let! message = mailbox.Receive ()
+                
+            match message with
+            // outright invalid URLs
+            | ValidateRepo uri when uri |> String.IsNullOrEmpty || not (Uri.IsWellFormedUriString(uri, UriKind.Absolute)) ->
+                mailbox.Context.Sender <! InvalidRepo(uri, "Not a valid absolute URI")
+            // repos that at least have a valid absolute URL
+            | ValidateRepo uri ->
+                let continuation (task: System.Threading.Tasks.Task<Octokit.Repository>) : GithubActorMessage =
+                    match task.IsCanceled with
+                    | true -> InvalidRepo(uri, "Repo lookup timed out")
+                    | false ->
+                        match task.IsFaulted with
+                        | true -> InvalidRepo(uri, "Not a valid absolute URI")
+                        | false -> ValidRepo task.Result
+                
+                let (user, repo) = splitIntoOwnerAndRepo uri
+                let githubClient = getGithubClient ()
+                githubClient.Repository.Get(user, repo).ContinueWith continuation
+                |> Async.AwaitTask
+                |> pipeToWithSender mailbox.Self mailbox.Context.Sender // send the message back to ourselves but pass the real sender through
+            | InvalidRepo (uri, reason) ->
+                InvalidRepo(uri, reason) |> mailbox.Context.Sender.Forward
+            | ValidRepo repo ->
+                mailbox.Context.ActorSelection("akka://GithubActors/user/commander") <! CanAcceptJob({ Owner = repo.Owner.Login; Repo = repo.Name })
+            | UnableToAcceptJob key ->
+                mailbox.Context.ActorSelection("akka://GithubActors/user/mainform") <! UnableToAcceptJob key
+            | AbleToAcceptJob key ->
+                mailbox.Context.ActorSelection("akka://GithubActors/user/mainform") <! AbleToAcceptJob key
+            | _ -> return! processMessage ()
+
+            return! processMessage ()
+        }
+
+        processMessage ()
+
+    // TODO implement
+    let githubWorkerActor (mailbox: Actor<_>) =
+        
+        let githubClient = lazy (GithubClientFactory.getClient ())
+
+        let rec processMessage () = actor {
+            let! message = mailbox.Receive ()
+
+            match message with
+            | RetryableQuery query when isQueryStarrer query.Query || isQueryStarrers query.Query ->
+                match query.Query :?> GithubActorMessage with
+                | QueryStarrer login ->
+                    try
+                        let starredRepos =
+                            githubClient.Value.Activity.Starring.GetAllForUser (login)
+                            |> Async.AwaitTask
+                            |> Async.RunSynchronously
+
+                        mailbox.Context.Sender <! StarredReposForUser(login, starredRepos)
+                    with
+                    | ex -> mailbox.Context.Sender <! nextTry query // operation failed - let the parent know
+                | QueryStarrers repoKey ->
+                    try
+                        let users =
+                            githubClient.Value.Activity.Starring.GetAllStargazers (repoKey.Owner, repoKey.Repo)
+                            |> Async.AwaitTask
+                            |> Async.RunSynchronously
+                            |> Seq.toArray
+
+                        mailbox.Context.Sender <! UsersToQuery users
+                    with
+                    | ex -> mailbox.Context.Sender <! nextTry query // operation failed - let the parent know
+                | _ -> () // never reached
+            | _ -> ()
+
+            return! processMessage ()
+        }
+
+        processMessage ()
+
+
+    let githubCoordinatorActor (mailbox: Actor<_>) =
+                  
+        let startWorking repoKey (scheduler: IScheduler) =
+            {
+                ReceivedInitialUsers = false
+                CurrentRepo = repoKey
+                Subscribers = System.Collections.Generic.HashSet<IActorRef> ()
+                SimilarRepos = System.Collections.Generic.Dictionary<string, SimilarRepo> ()
+                GithubProgressStats = getDefaultStats ()
+                PublishTimer = new Cancelable (scheduler)
+            }      
+
+        // pre-start
+        let githubWorker = spawn mailbox.Context "worker" (githubWorkerActor)
+
+        let rec waiting () =
+            actor {
+                let! message = mailbox.Receive ()
+                
+                match message with
+                | CanAcceptJob repoKey ->
+                    mailbox.Context.Sender <! AbleToAcceptJob repoKey
+                | BeginJob repoKey ->
+                    githubWorker <! RetryableQuery { Query = QueryStarrers repoKey; AllowableTries = 4; CurrentAttempt = 0 }
+                    let newSettings = startWorking repoKey mailbox.Context.System.Scheduler
+                    return! working newSettings
+                | _ -> return! waiting ()
+
+                return! waiting ()
+            }
+        and working (settings: WorkerSettings) =
+            actor {
+                let! message = mailbox.Receive ()
+                
+                match message with
+                // received a downloaded user back from the github worker
+                | StarredReposForUser (login, repos) ->
+                    repos
+                    |> Seq.iter (fun repo -> 
+                        if not <| settings.SimilarRepos.ContainsKey repo.HtmlUrl then
+                            settings.SimilarRepos.[repo.HtmlUrl] <- { SimilarRepo.Repo = repo; SharedStarrers = 1 }
+                        else
+                            settings.SimilarRepos.[repo.HtmlUrl] <- increaseSharedStarrers settings.SimilarRepos.[repo.HtmlUrl]
+                    )
+                        
+                    return! working {settings with GithubProgressStats = userQueriesFinished settings.GithubProgressStats 1 }
+                | PublishUpdate ->
+                    // Check to see if the job has fully completed
+                    match settings.ReceivedInitialUsers && settings.GithubProgressStats.IsFinished with
+                    | true ->
+                        // All repos minus forks of the current one
+                        let sortedSimilarRepos =
+                            settings.SimilarRepos.Values
+                            |> Seq.filter (fun repo -> repo.Repo.Name <> settings.CurrentRepo.Repo)
+                            |> Seq.sortBy (fun repo -> -repo.SharedStarrers)
+
+                        // Update progress (both repos and users)
+                        settings.Subscribers
+                        |> Seq.iter (fun subscriber ->
+                            subscriber <! SimilarRepos sortedSimilarRepos
+                            subscriber <! GithubProgressStats settings.GithubProgressStats)
+
+                        settings.PublishTimer.Cancel ()
+                        return! waiting ()
+                    | false ->
+                        settings.Subscribers
+                        |> Seq.iter (fun subscriber -> subscriber <! GithubProgressStats settings.GithubProgressStats)
+                | UsersToQuery users ->
+                    // queue all the jobs
+                    users |> Seq.iter (fun user -> githubWorker <! RetryableQuery { Query = QueryStarrer user.Login; AllowableTries = 3; CurrentAttempt = 0 })
+                    return! working {settings with GithubProgressStats = setExpectedUserCount settings.GithubProgressStats users.Length; ReceivedInitialUsers = true }
+                // the actor is currently busy, cannot handle the job now
+                | CanAcceptJob repoKey ->
+                    mailbox.Context.Sender <! UnableToAcceptJob repoKey
+                | SubscribeToProgressUpdates subscriber ->
+                    // this is our first subscriber, which means we need to turn publishing on
+                    if settings.Subscribers.Count = 0 then
+                        mailbox.Context.System.Scheduler.ScheduleTellRepeatedly(
+                            TimeSpan.FromMilliseconds 100., TimeSpan.FromMilliseconds 30.,
+                            mailbox.Self, PublishUpdate, mailbox.Self, settings.PublishTimer)
+                    settings.Subscribers.Add subscriber |> ignore
+
+                // query failed, but can be retried
+                | RetryableQuery query when query.CanRetry ->
+                    githubWorker <! RetryableQuery query
+                // query failed, can't be retried, and it's a QueryStarrers operation - meaning that the entire job failed
+                | RetryableQuery query when not query.CanRetry && isQueryStarrers query.Query ->
+                    settings.Subscribers
+                    |> Seq.iter (fun subscriber -> subscriber <! JobFailed settings.CurrentRepo)
+
+                    return! waiting ()
+                // query failed, can't be retried, and it's a QueryStarrer operation - meaning that an individual operation failed
+                | RetryableQuery query when not query.CanRetry && isQueryStarrer query.Query ->
+                    return! working {settings with GithubProgressStats = incrementFailures settings.GithubProgressStats 1 }
+                | _ -> return! working settings
+
+                return! working settings
+            }
+
+        waiting ()
+
+
+    let githubCommanderActor (mailbox: Actor<_>) =
+
+        // pre-start
+        let coordinator = spawn mailbox.Context "coordinator" (githubCoordinatorActor)
+
+        // post-stop, kill off the old coordinator so we can recreate it from scratch
+        mailbox.Defer (fun _ -> coordinator <! PoisonPill.Instance)
+
+        // pass around the actor that sent the CanAcceptJob message
+        let rec processMessage canAcceptJobSender = actor {
+            let! message = mailbox.Receive ()
+                
+            match message with
+            | CanAcceptJob repoKey ->
+                coordinator <! CanAcceptJob repoKey
+                return! processMessage mailbox.Context.Sender
+            | UnableToAcceptJob repoKey ->
+                canAcceptJobSender <! UnableToAcceptJob repoKey
+            | AbleToAcceptJob repoKey ->
+                canAcceptJobSender <! AbleToAcceptJob repoKey
+                coordinator <! BeginJob repoKey // start processing messages
+                mailbox.Context.ActorSelection "akka://GithubActors/user/mainform" <! LaunchRepoResultsWindow(repoKey, coordinator) // launch the new window to view results of the processing
+            | _ -> return! processMessage canAcceptJobSender
+
+            return! processMessage canAcceptJobSender
+        }
+
+        processMessage null
+
+
+    let repoResultsActor (usersGrid: DataGridView) (statusLabel: ToolStripStatusLabel) (progressBar: ToolStripProgressBar) (mailbox: Actor<_>) =
+        let startProgress stats =
+            progressBar.Minimum <- 0
+            progressBar.Step <- 1
+            progressBar.Maximum <- stats.ExpectedUsers
+            progressBar.Value <- stats.UsersThusFar
+            progressBar.Visible <- true
+            statusLabel.Visible <- true
+
+        let displayProgress stats =
+            statusLabel.Text <- sprintf "%i out of %i users (%i failures) [%A elapsed]" stats.UsersThusFar stats.ExpectedUsers stats.QueryFailures stats.Elapsed
+
+        let stopProgress repo =
+            progressBar.Visible <- true
+            progressBar.ForeColor <- Color.Red
+            progressBar.Maximum <- 1
+            progressBar.Value <- 1
+            statusLabel.Visible <- true
+            statusLabel.Text <- sprintf "Failed to gather date for GitHub repository %s / %s" repo.Owner repo.Repo
+        
+        let displayRepo similarRepo =
+            let repo = similarRepo.Repo
+            let row = new DataGridViewRow()
+            row.CreateCells usersGrid
+            row.Cells.[0].Value <- repo.Owner.Login
+            row.Cells.[1].Value <- repo.Owner.Name
+            row.Cells.[2].Value <- repo.Owner.HtmlUrl
+            row.Cells.[3].Value <- similarRepo.SharedStarrers
+            row.Cells.[4].Value <- repo.OpenIssuesCount
+            row.Cells.[5].Value <- repo.StargazersCount
+            row.Cells.[6].Value <- repo.ForksCount
+            usersGrid.Rows.Add row |> ignore
+
+        let mutable hasSetProgress = false
+        let rec processMessage () = actor {
+            let! message = mailbox.Receive ()
+                
+            match message with
+            | GithubProgressStats stats -> // progress update
+                if not hasSetProgress && stats.ExpectedUsers > 0 then
+                    startProgress stats
+                    hasSetProgress <- true
+                displayProgress stats
+                progressBar.Value <- stats.UsersThusFar + stats.QueryFailures
+            | SimilarRepos repos -> // user update
+                repos |> Seq.iter displayRepo
+            | JobFailed repoKey -> // critical failure, like not being able to connect to Github
+                stopProgress repoKey
+            | _ -> ()
+
+            return! processMessage ()
+        }
+
+        processMessage ()

--- a/src/Unit-3/FSharpDoThis/App.config
+++ b/src/Unit-3/FSharpDoThis/App.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="akka" type="Akka.Configuration.Hocon.AkkaConfigurationSection, Akka" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <akka>
+    <hocon>
+      <![CDATA[
+          akka {
+            actor {
+              deployment {
+                # used to configure our MainFormActor
+                /mainform {
+                  dispatcher = akka.actor.synchronized-dispatcher #causes MainFormActor to run on the UI thread for WinForms
+                }
+                /authenticator {
+                  dispatcher = akka.actor.synchronized-dispatcher
+                }
+              }
+            }
+          }
+      ]]>
+    </hocon>
+  </akka>
+</configuration>

--- a/src/Unit-3/FSharpDoThis/AssemblyInfo.fs
+++ b/src/Unit-3/FSharpDoThis/AssemblyInfo.fs
@@ -1,0 +1,41 @@
+﻿namespace GithubActors.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("GithubActors")>]
+[<assembly: AssemblyDescription("")>]
+[<assembly: AssemblyConfiguration("")>]
+[<assembly: AssemblyCompany("")>]
+[<assembly: AssemblyProduct("GithubActors")>]
+[<assembly: AssemblyCopyright("Copyright ©  2017")>]
+[<assembly: AssemblyTrademark("")>]
+[<assembly: AssemblyCulture("")>]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("8f96bd67-3bc5-4702-b6d4-a0031b40add5")>]
+
+// Version information for an assembly consists of the following four values:
+// 
+//       Major Version
+//       Minor Version 
+//       Build Number
+//       Revision
+// 
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()

--- a/src/Unit-3/FSharpDoThis/GithubActors.fsproj
+++ b/src/Unit-3/FSharpDoThis/GithubActors.fsproj
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>8f96bd67-3bc5-4702-b6d4-a0031b40add5</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>GithubActors</RootNamespace>
+    <AssemblyName>GithubActors</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <Name>GithubActors</Name>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <Tailcalls>false</Tailcalls>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Debug\GithubActors.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <Tailcalls>true</Tailcalls>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <WarningLevel>3</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DocumentationFile>bin\Release\GithubActors.XML</DocumentationFile>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" />
+  <ItemGroup>
+    <Compile Include="AssemblyInfo.fs" />
+    <Compile Include="GithubClientFactory.fs" />
+    <Compile Include="Messages.fs" />
+    <Compile Include="Actors.fs" />
+    <Compile Include="ActorSystem.fs" />
+    <Compile Include="RepoResultsForm.fs" />
+    <Compile Include="LauncherForm.fs" />
+    <Compile Include="GithubAuthForm.fs" />
+    <Compile Include="Program.fs" />
+    <None Include="App.config" />
+    <Content Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Akka">
+      <HintPath>packages\Akka.1.2.0\lib\net45\Akka.dll</HintPath>
+    </Reference>
+    <Reference Include="Akka.FSharp">
+      <HintPath>packages\Akka.FSharp.1.2.0\lib\net45\Akka.FSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.Data.TypeProviders" />
+    <Reference Include="FSharp.PowerPack">
+      <HintPath>packages\FSPowerPack.Core.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.PowerPack.Linq">
+      <HintPath>packages\FSPowerPack.Linq.Community.3.0.0.0\Lib\Net40\FSharp.PowerPack.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="FsPickler">
+      <HintPath>packages\FsPickler.1.3.7\lib\net40\FsPickler.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Octokit">
+      <HintPath>packages\Octokit.0.21.1\lib\net45\Octokit.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Unit-3/FSharpDoThis/GithubActors.sln
+++ b/src/Unit-3/FSharpDoThis/GithubActors.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "GithubActors", "GithubActors.fsproj", "{8F96BD67-3BC5-4702-B6D4-A0031B40ADD5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8F96BD67-3BC5-4702-B6D4-A0031B40ADD5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F96BD67-3BC5-4702-B6D4-A0031B40ADD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F96BD67-3BC5-4702-B6D4-A0031B40ADD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F96BD67-3BC5-4702-B6D4-A0031B40ADD5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Unit-3/FSharpDoThis/GithubAuthForm.fs
+++ b/src/Unit-3/FSharpDoThis/GithubAuthForm.fs
@@ -1,0 +1,44 @@
+﻿namespace GithubActors
+
+open System
+open System.Drawing
+open System.Windows.Forms
+open System.Diagnostics
+open Akka.FSharp
+
+[<AutoOpen>]
+module GithubAuthForm =
+    let boldFont = new Font("Microsoft Sans Serif", 11.25f, FontStyle.Bold, GraphicsUnit.Point)
+    let regularFont = new Font("Microsoft Sans Serif", 11.25f, FontStyle.Regular, GraphicsUnit.Point)
+    
+    let form = new Form(Name = "GithubAuthForm", Visible = true, Text = "Sign in to GitHub", AutoScaleDimensions = SizeF(6.F, 13.F), AutoScaleMode = AutoScaleMode.Font, ClientSize = Size(582, 155))
+    let lblAccessToken = new Label(Name = "lblAccessToken", Text = "GitHub Access Token", Size = Size(172, 18), Location = Point(12, 8), TabIndex = 0, Font = boldFont, AutoSize = true)
+    let txtOAuth = new TextBox(Name = "txtOAuth", Size = Size(380, 24), Location = Point(190, 6), TabIndex = 1, Font = regularFont)
+    let lblAuthStatus = new Label(Name = "lblAuthStatus", Text = "status", Size = Size(88, 18), Location = Point(188, 32), TabIndex = 2, Font = regularFont, Visible = false, AutoSize = true)
+    let lblLinkGitHub = new LinkLabel(Name = "lblLinkGitHub", Text = "How to get a GitHub Access Token", Size = Size(272, 18), Location = Point(148, 128), TabIndex = 3, Font = boldFont, AutoSize = true)
+    let btnAuthenticate = new Button(Name = "btnAuthenticate", Text = "Authenticate", Size = Size(136, 32), Location = Point(214, 80), TabIndex = 4, Font = boldFont, UseVisualStyleBackColor = true)
+
+    form.SuspendLayout ()
+
+    form.Controls.Add lblAccessToken
+    form.Controls.Add txtOAuth
+    form.Controls.Add lblAuthStatus
+    form.Controls.Add lblLinkGitHub
+    form.Controls.Add btnAuthenticate
+
+    form.ResumeLayout false
+
+    let load () =
+        let launcherForm = LauncherForm.load ()
+        let authenticator = spawn ActorSystem.githubActors "authenticator" (Actors.githubAuthenticationActor lblAuthStatus form launcherForm)
+
+        lblLinkGitHub.LinkClicked.Add (fun _ -> Process.Start "https://help.github.com/articles/creating-an-access-token-for-command-line-use/" |> ignore)
+        btnAuthenticate.Click.Add (fun _ ->
+            if (String.IsNullOrEmpty txtOAuth.Text)
+                then
+                    lblAuthStatus.Text <- "Please enter a token."
+                    lblAuthStatus.Visible <- true
+                    lblAuthStatus.ForeColor <- Color.Orange
+                else authenticator <! Authenticate txtOAuth.Text)
+
+        form

--- a/src/Unit-3/FSharpDoThis/GithubClientFactory.fs
+++ b/src/Unit-3/FSharpDoThis/GithubClientFactory.fs
@@ -1,0 +1,16 @@
+﻿namespace GithubActors
+
+module GithubClientFactory =
+
+    open Octokit
+    open Octokit.Internal
+
+    let mutable oauthToken = ""
+
+    let setOauthToken token = oauthToken <- token
+
+    let getUnauthenticatedClient () =
+        GitHubClient (ProductHeaderValue "AkkaBootcamp-Unit3")
+
+    let getClient () =
+         GitHubClient (ProductHeaderValue "AkkaBootcamp-Unit3", InMemoryCredentialStore (Credentials oauthToken))

--- a/src/Unit-3/FSharpDoThis/LauncherForm.fs
+++ b/src/Unit-3/FSharpDoThis/LauncherForm.fs
@@ -1,0 +1,40 @@
+﻿namespace GithubActors
+
+open System.Drawing
+open System.Windows.Forms
+open Akka.FSharp
+
+[<AutoOpen>]
+module LauncherForm =
+    let boldFont = new Font("Microsoft Sans Serif", 11.25f, FontStyle.Bold, GraphicsUnit.Point)
+    let regularFont = new Font("Microsoft Sans Serif", 11.25f, FontStyle.Regular, GraphicsUnit.Point)
+    
+    let form = new Form(Name = "LauncherForm", Visible = false, Text = "Launcher", AutoScaleDimensions = SizeF(6.F, 13.F), AutoScaleMode = AutoScaleMode.Font, ClientSize = Size(582, 155))
+    let lblRepo = new Label(Name = "lblRepo", Text = "Repo URL", Size = Size(86, 18), Location = Point(3, 16), TabIndex = 0, Font = boldFont, AutoSize = true)
+    let txtRepoUrl = new TextBox(Name = "txtRepoUrl", Size = Size(456, 24), Location = Point(96, 13), TabIndex = 1, Font = regularFont)
+    let lblIsValid = new Label(Name = "lblIsValid", Text = "isValid", Size = Size(46, 18), Location = Point(96, 44), TabIndex = 2, Font = regularFont, Visible = false, AutoSize = true)
+    let btnLaunch = new Button(Name = "btnLaunch", Text = "GO", Size = Size(142, 32), Location = Point(218, 90), TabIndex = 4, Font = boldFont, UseVisualStyleBackColor = true)
+
+    form.SuspendLayout ()
+
+    form.Controls.Add lblRepo
+    form.Controls.Add txtRepoUrl
+    form.Controls.Add lblIsValid
+    form.Controls.Add btnLaunch
+
+    form.ResumeLayout false
+
+    let load () =
+
+        // TODO should return a RepoResultsForm
+        let createRepoResultsForm (repoKey: RepoKey) coordinator =
+            RepoResultsForm.createNew repoKey coordinator
+            
+        let mainFormActor = spawn ActorSystem.githubActors "mainform" (Actors.mainFormActor lblIsValid createRepoResultsForm)
+        let validator = spawn ActorSystem.githubActors "validator" (Actors.githubValidatorActor GithubClientFactory.getClient)
+        let commander = spawn ActorSystem.githubActors "commander" (Actors.githubCommanderActor)
+        
+        btnLaunch.Click.Add (fun _ -> mainFormActor <! ProcessRepo txtRepoUrl.Text)
+        form.FormClosing.Add (fun _ -> Application.Exit ())
+
+        form

--- a/src/Unit-3/FSharpDoThis/Messages.fs
+++ b/src/Unit-3/FSharpDoThis/Messages.fs
@@ -1,0 +1,109 @@
+﻿namespace GithubActors
+
+open System
+open Akka.Actor
+
+[<AutoOpen>]
+module GeneralTypes =
+
+    type RepoKey = { Owner: string; Repo: string }
+    
+    // RetryableQuery section
+    type RetryableQuery = {
+        Query: obj
+        AllowableTries: int
+        CurrentAttempt: int
+    } with
+        member this.RemainingTries = this.AllowableTries - this.CurrentAttempt
+        member this.CanRetry = this.RemainingTries > 0
+
+    let nextTry (retryableQuery: RetryableQuery) =
+        { retryableQuery with CurrentAttempt = retryableQuery.CurrentAttempt + 1 }
+
+    // SimilarRepo section
+    type SimilarRepo = {
+        Repo: Octokit.Repository
+        SharedStarrers: int
+    }
+
+    let increaseSharedStarrers similarRepo =
+        { similarRepo with SharedStarrers = similarRepo.SharedStarrers + 1 }
+
+    // GithubProgressStats section
+    type GithubProgressStats = {
+        ExpectedUsers: int
+        UsersThusFar: int
+        QueryFailures: int
+        StartTime: DateTime
+        EndTime: DateTime option
+    } with
+        member this.Elapsed = 
+            match this.EndTime with
+            | Some endTime -> endTime - this.StartTime
+            | None -> DateTime.UtcNow - this.StartTime
+        member this.IsFinished =
+            this.ExpectedUsers = (this.UsersThusFar + this.QueryFailures)
+
+    let getDefaultStats () =
+        {
+            ExpectedUsers = 0
+            UsersThusFar = 0
+            QueryFailures = 0
+            StartTime = DateTime.UtcNow
+            EndTime = None
+        }
+
+    let userQueriesFinished stats delta =
+        { stats with UsersThusFar = stats.UsersThusFar + delta }
+
+    let setExpectedUserCount stats totalExpectedUsers =
+        { stats with ExpectedUsers = totalExpectedUsers }
+
+    let incrementFailures stats delta =
+        { stats with QueryFailures = stats.QueryFailures + delta }
+
+    let finish stats =
+        { stats with EndTime = Some DateTime.UtcNow }
+
+    // WorkerSettings section
+    type WorkerSettings = {
+        ReceivedInitialUsers: bool
+        CurrentRepo: RepoKey
+        Subscribers: System.Collections.Generic.HashSet<IActorRef>
+        SimilarRepos: System.Collections.Generic.Dictionary<string, SimilarRepo>
+        GithubProgressStats: GithubProgressStats
+        PublishTimer: Cancelable
+    }
+    
+[<AutoOpen>]
+module Messages =
+    
+    type AuthenticationMessage =
+        | Authenticate of oauthToken: string
+        | AuthenticationFailed
+        | AuthenticationCancelled
+        | AuthenticationSuccess
+
+    type GithubActorMessage =
+        // Job-related
+        | AbleToAcceptJob of repoKey: RepoKey
+        | UnableToAcceptJob of repoKey: RepoKey
+        | CanAcceptJob of repoKey: RepoKey
+        | BeginJob of repoKey: RepoKey
+        | JobFailed of repoKey: RepoKey
+        // Repo-related
+        | ValidateRepo of repoUri: string
+        | ValidRepo of repo: Octokit.Repository
+        | InvalidRepo of repoUri: string * reason: string
+        | ProcessRepo of repoUri: string
+        // Query-related
+        | LaunchRepoResultsWindow of repoKey: RepoKey * coordinator: IActorRef
+        | StarredReposForUser of login: string * repos: Octokit.Repository seq
+        | PublishUpdate        
+        | SubscribeToProgressUpdates of subscriber: IActorRef
+        | RetryableQuery of query: RetryableQuery
+        | QueryStarrers of repoKey: RepoKey
+        | QueryStarrer of login: string
+        | UsersToQuery of users: Octokit.User array
+        | GithubProgressStats of stats: GithubProgressStats
+        | SimilarRepos of repos: SimilarRepo seq

--- a/src/Unit-3/FSharpDoThis/Program.fs
+++ b/src/Unit-3/FSharpDoThis/Program.fs
@@ -1,0 +1,11 @@
+﻿module Program
+
+open System
+open System.Windows.Forms
+open GithubActors
+
+Application.EnableVisualStyles ()
+Application.SetCompatibleTextRenderingDefault false
+
+[<STAThread>]
+do Application.Run (GithubAuthForm.load ())

--- a/src/Unit-3/FSharpDoThis/RepoResultsForm.fs
+++ b/src/Unit-3/FSharpDoThis/RepoResultsForm.fs
@@ -9,6 +9,11 @@ open Akka.FSharp
 
 [<AutoOpen>]
 module RepoResultsForm =
+
+    let generateRandomActorName () =
+        Guid.NewGuid().ToString().[0..7]
+        |> sprintf "repoResults%s"
+
     let createNew (repoKey: RepoKey) (coordinator: IActorRef) =
         
         let formTitle = sprintf "Repos similar to %s / %s" repoKey.Owner repoKey.Repo
@@ -66,8 +71,9 @@ module RepoResultsForm =
         statusStrip.PerformLayout ()
         form.ResumeLayout false
         form.PerformLayout ()
-                
-        let repoResultsActor = spawnOpt ActorSystem.githubActors "repoResults" (Actors.repoResultsActor dgUsers lblStatus progressBar) [SpawnOption.Dispatcher "akka.actor.synchronized-dispatcher"]
+        
+        let actorName = generateRandomActorName ()
+        let repoResultsActor = spawnOpt ActorSystem.githubActors actorName (Actors.repoResultsActor dgUsers lblStatus progressBar) [SpawnOption.Dispatcher "akka.actor.synchronized-dispatcher"]
         coordinator <! SubscribeToProgressUpdates repoResultsActor
 
         form.FormClosing.Add (fun _ -> 

--- a/src/Unit-3/FSharpDoThis/RepoResultsForm.fs
+++ b/src/Unit-3/FSharpDoThis/RepoResultsForm.fs
@@ -1,0 +1,77 @@
+﻿namespace GithubActors
+
+open System
+open System.Drawing
+open System.Windows.Forms
+open System.ComponentModel
+open Akka.Actor
+open Akka.FSharp
+
+[<AutoOpen>]
+module RepoResultsForm =
+    let createNew (repoKey: RepoKey) (coordinator: IActorRef) =
+        
+        let formTitle = sprintf "Repos similar to %s / %s" repoKey.Owner repoKey.Repo
+        let form = new Form(Name = "RepoResultsForm", Visible = false, Text = formTitle, AutoScaleDimensions = SizeF(6.F, 13.F), AutoScaleMode = AutoScaleMode.Font, ClientSize = Size(740, 322))
+        
+        let dgUsers = new DataGridView()
+        let statusStrip = new StatusStrip()
+        let progressBar = new ToolStripProgressBar()
+        let lblStatus = new ToolStripStatusLabel()
+
+        (dgUsers :> ISupportInitialize).BeginInit ()
+        statusStrip.SuspendLayout ()        
+        form.SuspendLayout ()
+
+        dgUsers.Name <- "dgUsers"
+        dgUsers.AllowUserToOrderColumns <- true
+        dgUsers.ColumnHeadersHeightSizeMode <- DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        let columns : DataGridViewColumn [] = [|
+            new DataGridViewTextBoxColumn(HeaderText = "Owner", Name = "colOwner") // owner
+            new DataGridViewTextBoxColumn(HeaderText = "Repo Name", Name = "colRepoName") // repo name
+            new DataGridViewLinkColumn(HeaderText = "URL", Name = "colUrl", AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill) // URL
+            new DataGridViewTextBoxColumn(HeaderText = "Shared", Name = "colShared") // shared
+            new DataGridViewTextBoxColumn(HeaderText = "Issues", Name = "colIssues") // issues
+            new DataGridViewTextBoxColumn(HeaderText = "Stars", Name = "colStars") // stars
+            new DataGridViewTextBoxColumn(HeaderText = "Forks", Name = "colForks") // forks
+        |]
+        dgUsers.Columns.AddRange columns
+        dgUsers.Dock <- DockStyle.Fill
+        dgUsers.TabIndex <- 0
+        dgUsers.Size <- Size(740, 322)
+        dgUsers.Location <- Point(0, 0)
+
+        statusStrip.Name <- "statusStrip"
+        statusStrip.Text <- "status"
+        let items : ToolStripItem [] = [| progressBar; lblStatus |]
+        statusStrip.Items.AddRange items
+        statusStrip.Location <- Point(0, 300)
+        statusStrip.Size <- Size(740, 22)
+        statusStrip.TabIndex <- 1
+
+        progressBar.Name <- "progressBar"
+        progressBar.Size <- Size(100, 16)
+        progressBar.Visible <- false
+
+        lblStatus.Name <- "lblStatus"
+        lblStatus.Text <- "Processing..."
+        lblStatus.Size <- Size(72, 16)
+        lblStatus.Visible <- false
+                
+        form.Controls.Add statusStrip
+        form.Controls.Add dgUsers
+
+        (dgUsers :> ISupportInitialize).EndInit ()
+        statusStrip.ResumeLayout false
+        statusStrip.PerformLayout ()
+        form.ResumeLayout false
+        form.PerformLayout ()
+                
+        let repoResultsActor = spawnOpt ActorSystem.githubActors "repoResults" (Actors.repoResultsActor dgUsers lblStatus progressBar) [SpawnOption.Dispatcher "akka.actor.synchronized-dispatcher"]
+        coordinator <! SubscribeToProgressUpdates repoResultsActor
+
+        form.FormClosing.Add (fun _ -> 
+            //
+            repoResultsActor <! PoisonPill.Instance)
+              
+        form

--- a/src/Unit-3/FSharpDoThis/packages.config
+++ b/src/Unit-3/FSharpDoThis/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Akka" version="1.2.0" targetFramework="net45" />
+  <package id="Akka.FSharp" version="1.2.0" targetFramework="net45" />
+  <package id="FsPickler" version="1.3.7" targetFramework="net45" />
+  <package id="FSPowerPack.Core.Community" version="3.0.0.0" targetFramework="net45" />
+  <package id="FSPowerPack.Linq.Community" version="3.0.0.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net45" />
+  <package id="Octokit" version="0.21.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
The code is working and returning the same results as the C# version.

**Performance comparison:**
Tested with the following repo: https://github.com/WaveEngine/Extensions

_C# times:_ 
4167 results in 51.01s | 51.60s | 50.77s | 50.16s | 51.19s
Avg: 50.95s

_F# times:_
4167 results in 50.24s | 50.58s | 49.43s | 50.55s | 52.19s
Avg: 50.60s

**Bugs fixed:**
1. in the F# version, clicking on GO from the LauncherForm after having fetched the results once causes to create a new RepoResultForm and a new repoResultsActor with the same name as the previous one (actor with same name already exists...). The coordinator should probably prevent this from happening.
**Fixed** by generating the actor name randomly (in C# the actor is created without being explicitly given a name).

2. It seems that after prematurely closing a RepoResultForm, the mainFormActor gets stuck in the busy state.
**EDIT**: the same behaviour can be observed in the C# version...

3. The F# version seems to display the results on the grid much slower than the C# version.
**EDIT:** after debugging some more, it seems that the C# version also takes a few seconds to update the results grid.
**Fixed**: The EndTime was not properly set in F# and the the timer was running during the UI update.

