### PR TITLE
Moving the FileObserver class definition

### DIFF
--- a/src/Unit-1/lesson4/README.md
+++ b/src/Unit-1/lesson4/README.md
@@ -241,9 +241,131 @@ The goal of this exercise is to show you how to make a parent/child actor relati
 ### Phase 1: Make your first parent/child actors!
 We're ready to create our actor classes that will form a parent/child relationship.
 
+#### Add `TailActor`
+Add a class called `TailActor` in its own file. This actor is the actor that is actually responsible for tailing a given file. `TailActor` will be created and supervised by `TailCoordinatorActor` in a moment.
+For now, add the following code in `TailActor.cs`:
+
+```csharp
+// TailActor.cs
+using System.IO;
+using System.Text;
+using Akka.Actor;
+
+namespace WinTail
+{
+    /// <summary>
+    /// Monitors the file at <see cref="_filePath"/> for changes and sends
+    /// file updates to console.
+    /// </summary>
+    public class TailActor : UntypedActor
+    {
+        #region Message types
+
+        /// <summary>
+        /// Signal that the file has changed, and we need to 
+        /// read the next line of the file.
+        /// </summary>
+        public class FileWrite
+        {
+            public FileWrite(string fileName)
+            {
+                FileName = fileName;
+            }
+
+            public string FileName { get; private set; }
+        }
+
+        /// <summary>
+        /// Signal that the OS had an error accessing the file.
+        /// </summary>
+        public class FileError
+        {
+            public FileError(string fileName, string reason)
+            {
+                FileName = fileName;
+                Reason = reason;
+            }
+
+            public string FileName { get; private set; }
+
+            public string Reason { get; private set; }
+        }
+
+        /// <summary>
+        /// Signal to read the initial contents of the file at actor startup.
+        /// </summary>
+        public class InitialRead
+        {
+            public InitialRead(string fileName, string text)
+            {
+                FileName = fileName;
+                Text = text;
+            }
+
+            public string FileName { get; private set; }
+            public string Text { get; private set; }
+        }
+
+        #endregion
+
+        private readonly string _filePath;
+        private readonly IActorRef _reporterActor;
+        private readonly FileObserver _observer;
+        private readonly Stream _fileStream;
+        private readonly StreamReader _fileStreamReader;
+
+        public TailActor(IActorRef reporterActor, string filePath)
+        {
+            _reporterActor = reporterActor;
+            _filePath = filePath;
+
+            // start watching file for changes
+            _observer = new FileObserver(Self, Path.GetFullPath(_filePath));
+            _observer.Start();
+
+            // open the file stream with shared read/write permissions
+            // (so file can be written to while open)
+            _fileStream = new FileStream(Path.GetFullPath(_filePath),
+                FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            _fileStreamReader = new StreamReader(_fileStream, Encoding.UTF8);
+
+            // read the initial contents of the file and send it to console as first msg
+            var text = _fileStreamReader.ReadToEnd();
+            Self.Tell(new InitialRead(_filePath, text));
+        }
+
+        protected override void OnReceive(object message)
+        {
+            if (message is FileWrite)
+            {
+                // move file cursor forward
+                // pull results from cursor to end of file and write to output
+                // (this is assuming a log file type format that is append-only)
+                var text = _fileStreamReader.ReadToEnd();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    _reporterActor.Tell(text);
+                }
+
+            }
+            else if (message is FileError)
+            {
+                var fe = message as FileError;
+                _reporterActor.Tell(string.Format("Tail error: {0}", fe.Reason));
+            }
+            else if (message is InitialRead)
+            {
+                var ir = message as InitialRead;
+                _reporterActor.Tell(ir.Text);
+            }
+        }
+    }
+}
+```
+
+
 #### Add `FileObserver`
 This is a utility class that we're providing for you to use. It does the low-level work of actually watching a file for changes.
-
 Create a new class called `FileObserver` and type in the code for [FileObserver.cs](Completed/FileObserver.cs). If you're running this on Mono, note the extra environment variable that has to be uncommented in the `Start()` method:
 
 ```csharp
@@ -399,135 +521,9 @@ namespace WinTail
 ```
 
 
-
-#### Add `TailActor`
-Now, add a class called `TailActor` in its own file. This actor is the actor that is actually responsible for tailing a given file. `TailActor` will be created and supervised by `TailCoordinatorActor` in a moment.
-
-For now, add the following code in `TailActor.cs`:
-
-```csharp
-// TailActor.cs
-using System.IO;
-using System.Text;
-using Akka.Actor;
-
-namespace WinTail
-{
-    /// <summary>
-    /// Monitors the file at <see cref="_filePath"/> for changes and sends
-    /// file updates to console.
-    /// </summary>
-    public class TailActor : UntypedActor
-    {
-        #region Message types
-
-        /// <summary>
-        /// Signal that the file has changed, and we need to 
-        /// read the next line of the file.
-        /// </summary>
-        public class FileWrite
-        {
-            public FileWrite(string fileName)
-            {
-                FileName = fileName;
-            }
-
-            public string FileName { get; private set; }
-        }
-
-        /// <summary>
-        /// Signal that the OS had an error accessing the file.
-        /// </summary>
-        public class FileError
-        {
-            public FileError(string fileName, string reason)
-            {
-                FileName = fileName;
-                Reason = reason;
-            }
-
-            public string FileName { get; private set; }
-
-            public string Reason { get; private set; }
-        }
-
-        /// <summary>
-        /// Signal to read the initial contents of the file at actor startup.
-        /// </summary>
-        public class InitialRead
-        {
-            public InitialRead(string fileName, string text)
-            {
-                FileName = fileName;
-                Text = text;
-            }
-
-            public string FileName { get; private set; }
-            public string Text { get; private set; }
-        }
-
-        #endregion
-
-        private readonly string _filePath;
-        private readonly IActorRef _reporterActor;
-        private readonly FileObserver _observer;
-        private readonly Stream _fileStream;
-        private readonly StreamReader _fileStreamReader;
-
-        public TailActor(IActorRef reporterActor, string filePath)
-        {
-            _reporterActor = reporterActor;
-            _filePath = filePath;
-
-            // start watching file for changes
-            _observer = new FileObserver(Self, Path.GetFullPath(_filePath));
-            _observer.Start();
-
-            // open the file stream with shared read/write permissions
-            // (so file can be written to while open)
-            _fileStream = new FileStream(Path.GetFullPath(_filePath),
-                FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            _fileStreamReader = new StreamReader(_fileStream, Encoding.UTF8);
-
-            // read the initial contents of the file and send it to console as first msg
-            var text = _fileStreamReader.ReadToEnd();
-            Self.Tell(new InitialRead(_filePath, text));
-        }
-
-        protected override void OnReceive(object message)
-        {
-            if (message is FileWrite)
-            {
-                // move file cursor forward
-                // pull results from cursor to end of file and write to output
-                // (this is assuming a log file type format that is append-only)
-                var text = _fileStreamReader.ReadToEnd();
-                if (!string.IsNullOrEmpty(text))
-                {
-                    _reporterActor.Tell(text);
-                }
-
-            }
-            else if (message is FileError)
-            {
-                var fe = message as FileError;
-                _reporterActor.Tell(string.Format("Tail error: {0}", fe.Reason));
-            }
-            else if (message is InitialRead)
-            {
-                var ir = message as InitialRead;
-                _reporterActor.Tell(ir.Text);
-            }
-        }
-    }
-}
-```
-
 #### Add `TailActor` as a child of `TailCoordinatorActor`
 Quick review: `TailActor` is to be a child of `TailCoordinatorActor` and will therefore be supervised by `TailCoordinatorActor`.
-
 This also means that `TailActor` must be created in the context of `TailCoordinatorActor`.
-
 Go to `TailCoordinatorActor.cs` and replace `OnReceive()` with the following code to create your first child actor!
 
 ```csharp


### PR DESCRIPTION
Moving the FileObserver class definition so that way code that depends on it is created later (no red squiggles to deal with when reading/implementing the document is nice)