### PR TITLE
Remove Even|Odd active pattern (1.2 - 1.6).

### DIFF
--- a/src/Unit-1/FSharp/lesson2/Completed/Actors.fs
+++ b/src/Unit-1/FSharp/lesson2/Completed/Actors.fs
@@ -55,10 +55,6 @@ module Actors =
         getAndValidateInput ()
             
     let consoleWriterActor message =
-        
-        // Active pattern matching to define if a number is even or odd
-        let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-    
         let printInColor color message =
             Console.ForegroundColor <- color
             Console.WriteLine (message.ToString ())

--- a/src/Unit-1/FSharp/lesson3/Completed/Actors.fs
+++ b/src/Unit-1/FSharp/lesson3/Completed/Actors.fs
@@ -34,8 +34,6 @@ module Actors =
 
 
     let consoleWriterActor message = 
-        let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-    
         let printInColor color message =
             Console.ForegroundColor <- color
             Console.WriteLine (message.ToString ())

--- a/src/Unit-1/FSharp/lesson4/Completed/Actors.fs
+++ b/src/Unit-1/FSharp/lesson4/Completed/Actors.fs
@@ -32,8 +32,6 @@ module Actors =
 
 
     let consoleWriterActor message =
-        let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-    
         let printInColor color message =
             Console.ForegroundColor <- color
             Console.WriteLine (message.ToString ())

--- a/src/Unit-1/FSharp/lesson5/Completed/Actors.fs
+++ b/src/Unit-1/FSharp/lesson5/Completed/Actors.fs
@@ -32,8 +32,6 @@ module Actors =
 
 
     let consoleWriterActor message =
-        let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-    
         let printInColor color message =
             Console.ForegroundColor <- color
             Console.WriteLine (message.ToString ())

--- a/src/Unit-1/FSharp/lesson6/Completed/Actors.fs
+++ b/src/Unit-1/FSharp/lesson6/Completed/Actors.fs
@@ -32,8 +32,6 @@ module Actors =
 
 
     let consoleWriterActor message =
-        let (|Even|Odd|) n = if n % 2 = 0 then Even else Odd
-    
         let printInColor color message =
             Console.ForegroundColor <- color
             Console.WriteLine (message.ToString ())


### PR DESCRIPTION
Removes an unused active pattern from the "complete" solutions for Unit 1.

The active pattern in question is only used during lesson 1.